### PR TITLE
AUTHORS.txt: use email instead of github username

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,5 +1,5 @@
 # Authors of GeoMet
-# Name (github-username) - Month Year
-Lars Butler (larsbutler) - March 2013
-? (maralla) - November 2013
-Sean Gillies (sgillies) - August 2014
+# Name <email address> - Month Year
+Lars Butler <lars.butler@gmail.com> - March 2013
+Maralla <maralla.ai@gmail.com> - November 2013
+Sean Gillies <sean.gillies@gmail.com> - August 2014


### PR DESCRIPTION
This decouples authorship from github, in case anyone wants to fork and
host the fork elsewhere.
