### PR TITLE
Correct the license in setup.py classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     keywords='wkb wkt geojson',
     classifiers=(
         'Development Status :: 4 - Beta',
-        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: Apache Software License',
         'Intended Audience :: Developers',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
I changed the license from BSD to Apache2, but forgot to update the
classifiers.