### PR TITLE
Add support for EWKT/EWKB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - "pip install tox"  # for running tests only
   - "python setup.py -q install"
-script: tox
+script: export PY_TEST_VERSION=py$(echo ${TRAVIS_PYTHON_VERSION} | sed 's/\.//') && tox -e style,$PY_TEST_VERSION

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ GeoMet [![Build Status](https://secure.travis-ci.org/geomet/geomet.png?branch=ma
 
 Convert [GeoJSON](http://www.geojson.org/geojson-spec.html) to
 [WKT/WKB](http://en.wikipedia.org/wiki/Well-known_text) (Well-Known
-Text/Binary), and vice versa. Conversion functions are exposed through
+Text/Binary), and vice versa. [Extended WKB/WKT](https://postgis.net/docs/using_postgis_dbmanagement.html#EWKB_EWKT)
+are also supported. Conversion functions are exposed through
 idiomatic `load/loads/dump/dumps` interfaces.
 
 The name "GeoMet" was inspired by "met", the German word for
@@ -15,7 +16,7 @@ GeoMet is intended to cover all common use cases for dealing with 2D, 3D, and
 
 The following conversion functions are supported.
 
-WKT <--> GeoJSON:
+WKT/EWKT <--> GeoJSON:
 
 - Point
 - LineString
@@ -25,7 +26,7 @@ WKT <--> GeoJSON:
 - MultiPolygon
 - GeometryCollection
 
-WKB <--> GeoJSON:
+WKB/EWKB <--> GeoJSON:
 
 - Point
 - LineString
@@ -90,6 +91,20 @@ Coverting 'GeometryCollection' WKT to GeoJSON:
 
     >>> wkt.loads('GEOMETRYCOLLECTION(POINT(10 20),POLYGON(((0 0), (10 30), (30 10), (0 0)))')
     {'type': 'GeometryCollection', 'geometries': [{'type': 'Point', 'coordinates': [10.0, 20.0]}, {'type': 'Polygon', 'coordinates': [[[0.0, 0.0]], [[10.0, 30.0]], [[30.0, 10.0]], [[0.0, 0.0]]]}]}
+
+EWKT/EWKB are also supported for all geometry types. This uses a custom extension
+to the GeoJSON standard in order to preserve SRID information through conversions.
+For example:
+
+    >>> wkt.loads('SRID=4326;POINT(10 20)')
+    {'type': 'Point', 'coordinates': [10.0, 20.0], 'meta': {'srid': '4326'}}
+    >>> wkt.dumps({'type': 'Point', 'coordinates': [10.0, 20.0], 'meta': {'srid': '4326'}, 'crs': {'properties': {'name': 'EPSG4326'}, 'type': 'name'}})
+    'SRID=4326;POINT (10.0000000000000000 20.0000000000000000)'
+    >>> wkb.loads('\x00 \x00\x00\x01\x00\x00\x10\xe6@$\x00\x00\x00\x00\x00\x00@4\x00\x00\x00\x00\x00\x00')
+    {'meta': {'srid': '4326'}, 'type': 'Point', 'coordinates': [10.0, 20.0]}
+    >>> wkb.dumps({'type': 'Point', 'coordinates': [10.0, 20.0], 'meta': {'srid': '4326'}, 'crs': {'properties': {'name': 'EPSG4326'}, 'type': 'name'}})
+    '\x00 \x00\x00\x01\x00\x00\x10\xe6@$\x00\x00\x00\x00\x00\x00@4\x00\x00\x00\x00\x00\x00'
+
 
 ### See Also ###
 

--- a/README.md
+++ b/README.md
@@ -108,4 +108,5 @@ For example:
 
 ### See Also ###
 
-- [wellknown](https://github.com/mapbox/wellknown) provides similar features for Node.
+- [wellknown](https://github.com/mapbox/wellknown): A similar package for Node.js.
+- [geo](https://github.com/bryanjos/geo): A nearly-identical package for Elixir.

--- a/geomet/tests/wkb_test.py
+++ b/geomet/tests/wkb_test.py
@@ -81,6 +81,20 @@ class PointTestCase(unittest.TestCase):
             b'\x00\x00\x00\x00\x00\x00\x10@'
         )
 
+        self.pt2d_srid4326 = dict(
+            type='Point',
+            coordinates=[0.0, 1.0],
+            meta=dict(srid=4326),
+            crs={'properties': {'name': 'EPSG4326'}, 'type': 'name'},
+        )
+        self.pt2d_srid4326_wkb = (
+            b'\x01'  # little endian
+            b'\x01\x00\x00\x20'  # type, with SRID flag set (0x20)
+            b'\xe6\x10\x00\x00'  # 4 bytes containing SRID (SRID=4326)
+            b'\x00\x00\x00\x00\x00\x00\x00\x00'
+            b'\x00\x00\x00\x00\x00\x00\xf0?'
+        )
+
     def test_dumps_2d(self):
         self.assertEqual(self.pt2d_wkb, wkb.dumps(self.pt2d, big_endian=False))
 
@@ -112,6 +126,9 @@ class PointTestCase(unittest.TestCase):
 
     def test_loads_zm(self):
         self.assertEqual(self.pt4d, wkb.loads(self.pt4d_wkb))
+
+    def test_loads_2d_srid4326(self):
+        self.assertEqual(self.pt2d_srid4326, wkb.loads(self.pt2d_srid4326_wkb))
 
 
 class LineStringTestCase(unittest.TestCase):
@@ -158,6 +175,23 @@ class LineStringTestCase(unittest.TestCase):
             b'\xbf\xec\xcc\xcc\xcc\xcc\xcc\xcd'  # -0.9
         )
 
+        self.ls2d_srid1234 = dict(
+            type='LineString',
+            coordinates=[[2.2, 4.4], [3.1, 5.1]],
+            meta=dict(srid=1234),
+            crs={'properties': {'name': 'EPSG1234'}, 'type': 'name'},
+        )
+        self.ls2d_srid1234_wkb = (
+            b'\x00'  # big endian
+            b'\x20\x00\x00\x02'  # type with SRID flag set
+            b'\x00\x00\x04\xd2'  # srid
+            b'\x00\x00\x00\x02'  # 2 vertices
+            b'@\x01\x99\x99\x99\x99\x99\x9a'  # 2.2
+            b'@\x11\x99\x99\x99\x99\x99\x9a'  # 4.4
+            b'@\x08\xcc\xcc\xcc\xcc\xcc\xcd'  # 3.1
+            b'@\x14ffffff'                    # 5.1
+        )
+
     def test_dumps_2d(self):
         self.assertEqual(self.ls2d_wkb, wkb.dumps(self.ls2d))
 
@@ -166,6 +200,9 @@ class LineStringTestCase(unittest.TestCase):
 
     def test_dumps_4d(self):
         self.assertEqual(self.ls4d_wkb, wkb.dumps(self.ls4d))
+
+    def test_dumps_2d_srid1234(self):
+        self.assertEqual(self.ls2d_srid1234_wkb, wkb.dumps(self.ls2d_srid1234))
 
     def test_loads_2d(self):
         self.assertEqual(self.ls2d, wkb.loads(self.ls2d_wkb))
@@ -184,6 +221,9 @@ class LineStringTestCase(unittest.TestCase):
 
     def test_loads_zm(self):
         self.assertEqual(self.ls4d, wkb.loads(self.ls4d_wkb))
+
+    def test_loads_2d_srid1234(self):
+        self.assertEqual(self.ls2d_srid1234, wkb.loads(self.ls2d_srid1234_wkb))
 
 
 class PolygonTestCase(unittest.TestCase):
@@ -328,7 +368,8 @@ class PolygonTestCase(unittest.TestCase):
                 [[100.201, 0.201], [100.801, 0.201], [100.801, 0.801],
                  [100.201, 0.201]],
             ],
-            meta=dict(srid='26918'),
+            meta=dict(srid=26918),
+            crs={'properties': {'name': 'EPSG26918'}, 'type': 'name'},
         )
 
         self.poly2d_srid26918_wkb = (
@@ -369,6 +410,11 @@ class PolygonTestCase(unittest.TestCase):
 
     def test_dumps_4d(self):
         self.assertEqual(self.poly4d_wkb, wkb.dumps(self.poly4d))
+
+    def test_dumps_2d_srid26918(self):
+        self.assertEqual(
+            self.poly2d_srid26918_wkb, wkb.dumps(self.poly2d_srid26918)
+        )
 
     def test_loads_2d(self):
         self.assertEqual(self.poly2d, wkb.loads(self.poly2d_wkb))
@@ -480,6 +526,34 @@ class MultiPointTestCase(unittest.TestCase):
             b'\x00\x00\x00\x00\x00\x00\x00\x00'  # 0.0
             b'\x9a\x99\x99\x99\x99\x99\x11@'     # 4.4
         )
+        self.multipoint2d_srid664 = dict(
+            type='MultiPoint',
+            coordinates=[[2.2, 4.4], [10.0, 3.1], [5.1, 20.0]],
+            meta=dict(srid=664),
+            crs={'properties': {'name': 'EPSG664'}, 'type': 'name'},
+        )
+        self.multipoint2d_srid664_wkb = (
+            b'\x01'  # little endian
+            b'\x04\x00\x00\x20'  # type with SRID flag set
+            b'\x98\x02\x00\x00'  # SRID 664
+            # number of points: 3
+            b'\x03\x00\x00\x00'
+            # point 2d
+            b'\x01'  # little endian
+            b'\x01\x00\x00\x00'
+            b'\x9a\x99\x99\x99\x99\x99\x01@'  # 2.2
+            b'\x9a\x99\x99\x99\x99\x99\x11@'  # 4.4
+            # point 2d
+            b'\x01'  # little endian
+            b'\x01\x00\x00\x00'
+            b'\x00\x00\x00\x00\x00\x00$@'     # 10.0
+            b'\xcd\xcc\xcc\xcc\xcc\xcc\x08@'  # 3.1
+            # point 2d
+            b'\x01'  # little endian
+            b'\x01\x00\x00\x00'
+            b'ffffff\x14@'                    # 5.1
+            b'\x00\x00\x00\x00\x00\x004@'     # 20.0
+        )
 
     def test_dumps_2d(self):
         self.assertEqual(
@@ -497,6 +571,12 @@ class MultiPointTestCase(unittest.TestCase):
         self.assertEqual(
             self.multipoint4d_wkb,
             wkb.dumps(self.multipoint4d, big_endian=False)
+        )
+
+    def test_dumps_2d_srid664(self):
+        self.assertEqual(
+            self.multipoint2d_srid664_wkb,
+            wkb.dumps(self.multipoint2d_srid664, big_endian=False),
         )
 
     def test_loads_2d(self):
@@ -539,6 +619,12 @@ class MultiPointTestCase(unittest.TestCase):
 
     def test_loads_zm(self):
         self.assertEqual(self.multipoint4d, wkb.loads(self.multipoint4d_wkb))
+
+    def test_loads_2d_srid664(self):
+        self.assertEqual(
+            wkb.loads(self.multipoint2d_srid664_wkb),
+            self.multipoint2d_srid664,
+        )
 
 
 class MultiLineStringTestCase(unittest.TestCase):
@@ -627,6 +713,36 @@ class MultiLineStringTestCase(unittest.TestCase):
             b'\x9a\x99\x99\x99\x99\x99\x11@'     # 4.4
         )
 
+        self.mls2d_srid4326 = dict(
+            type='MultiLineString',
+            coordinates=[[[2.2, 4.4], [3.1, 5.1], [5.1, 20.0]],
+                         [[20.0, 2.2], [3.1, 4.4]]],
+            meta=dict(srid=4326),
+            crs={'properties': {'name': 'EPSG4326'}, 'type': 'name'},
+        )
+        self.mls2d_srid4326_wkb = (
+            b'\x00'
+            b'\x20\x00\x00\x05'  # type with SRID flag set
+            b'\x00\x00\x10\xe6'  # SRID 4326
+            b'\x00\x00\x00\x02'  # number of linestrings
+            b'\x00'
+            b'\x00\x00\x00\x02'
+            b'\x00\x00\x00\x03'
+            b'@\x01\x99\x99\x99\x99\x99\x9a'  # 2.2
+            b'@\x11\x99\x99\x99\x99\x99\x9a'  # 4.4
+            b'@\x08\xcc\xcc\xcc\xcc\xcc\xcd'  # 3.1
+            b'@\x14ffffff'                    # 5.1
+            b'@\x14ffffff'                    # 5.1
+            b'@4\x00\x00\x00\x00\x00\x00'     # 20.0
+            b'\x00'
+            b'\x00\x00\x00\x02'
+            b'\x00\x00\x00\x02'
+            b'@4\x00\x00\x00\x00\x00\x00'     # 20.0
+            b'@\x01\x99\x99\x99\x99\x99\x9a'  # 2.2
+            b'@\x08\xcc\xcc\xcc\xcc\xcc\xcd'  # 3.1
+            b'@\x11\x99\x99\x99\x99\x99\x9a'  # 4.4
+        )
+
     def test_dumps_2d(self):
         self.assertEqual(self.mls2d_wkb, wkb.dumps(self.mls2d))
 
@@ -636,6 +752,11 @@ class MultiLineStringTestCase(unittest.TestCase):
     def test_dumps_4d(self):
         self.assertEqual(self.mls4d_wkb,
                          wkb.dumps(self.mls4d, big_endian=False))
+
+    def test_dumps_2d_srid4326(self):
+        self.assertEqual(
+            self.mls2d_srid4326_wkb, wkb.dumps(self.mls2d_srid4326)
+        )
 
     def test_loads_2d(self):
         self.assertEqual(self.mls2d, wkb.loads(self.mls2d_wkb))
@@ -679,6 +800,11 @@ class MultiLineStringTestCase(unittest.TestCase):
 
     def test_loads_zm(self):
         self.assertEqual(self.mls4d, wkb.loads(self.mls4d_wkb))
+
+    def test_loads_2d_srid4326(self):
+        self.assertEqual(
+            self.mls2d_srid4326, wkb.loads(self.mls2d_srid4326_wkb)
+        )
 
 
 class MultiPolygonTestCase(unittest.TestCase):
@@ -889,6 +1015,65 @@ class MultiPolygonTestCase(unittest.TestCase):
             b'\x00\x00\x00\x00\x00\x00\x00\x00'
         )
 
+        self.mpoly2d_srid4326 = dict(
+            type='MultiPolygon',
+            coordinates=[
+                [[[102.0, 2.0], [103.0, 2.0], [103.0, 3.0], [102.0, 3.0],
+                  [102.0, 2.0]]],
+                [[[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0],
+                  [100.0, 0.0]],
+                 [[100.2, 0.2], [100.8, 0.2], [100.8, 0.8], [100.2, 0.8],
+                  [100.2, 0.2]]],
+            ],
+            meta=dict(srid=4326),
+            crs={'properties': {'name': 'EPSG4326'}, 'type': 'name'},
+        )
+        self.mpoly2d_srid4326_wkb = (
+            b'\x01'  # little endian
+            b'\x06\x00\x00\x20'  # 2d multipolygon wth SRID flag
+            b'\xe6\x10\x00\x00'  # 4 bytes containing SRID (SRID=4326)
+            b'\x02\x00\x00\x00'  # two polygons
+            b'\x01'  # little endian
+            b'\x03\x00\x00\x00'  # 2d polygon
+            b'\x01\x00\x00\x00'  # 1 ring
+            b'\x05\x00\x00\x00'  # 5 vertices
+            b'\x00\x00\x00\x00\x00\x80Y@'
+            b'\x00\x00\x00\x00\x00\x00\x00@'
+            b'\x00\x00\x00\x00\x00\xc0Y@'
+            b'\x00\x00\x00\x00\x00\x00\x00@'
+            b'\x00\x00\x00\x00\x00\xc0Y@'
+            b'\x00\x00\x00\x00\x00\x00\x08@'
+            b'\x00\x00\x00\x00\x00\x80Y@'
+            b'\x00\x00\x00\x00\x00\x00\x08@'
+            b'\x00\x00\x00\x00\x00\x80Y@'
+            b'\x00\x00\x00\x00\x00\x00\x00@'
+            b'\x01'  # little endian
+            b'\x03\x00\x00\x00'  # 2d polygon
+            b'\x02\x00\x00\x00'  # 2 rings
+            b'\x05\x00\x00\x00'  # first ring, 5 vertices
+            b'\x00\x00\x00\x00\x00\x00Y@'
+            b'\x00\x00\x00\x00\x00\x00\x00\x00'
+            b'\x00\x00\x00\x00\x00@Y@'
+            b'\x00\x00\x00\x00\x00\x00\x00\x00'
+            b'\x00\x00\x00\x00\x00@Y@'
+            b'\x00\x00\x00\x00\x00\x00\xf0?'
+            b'\x00\x00\x00\x00\x00\x00Y@'
+            b'\x00\x00\x00\x00\x00\x00\xf0?'
+            b'\x00\x00\x00\x00\x00\x00Y@'
+            b'\x00\x00\x00\x00\x00\x00\x00\x00'
+            b'\x05\x00\x00\x00'  # second ring, 5 vertices
+            b'\xcd\xcc\xcc\xcc\xcc\x0cY@'
+            b'\x9a\x99\x99\x99\x99\x99\xc9?'
+            b'333333Y@'
+            b'\x9a\x99\x99\x99\x99\x99\xc9?'
+            b'333333Y@'
+            b'\x9a\x99\x99\x99\x99\x99\xe9?'
+            b'\xcd\xcc\xcc\xcc\xcc\x0cY@'
+            b'\x9a\x99\x99\x99\x99\x99\xe9?'
+            b'\xcd\xcc\xcc\xcc\xcc\x0cY@'
+            b'\x9a\x99\x99\x99\x99\x99\xc9?'
+        )
+
     def test_dumps_2d(self):
         self.assertEqual(self.mpoly2d_wkb,
                          wkb.dumps(self.mpoly2d, big_endian=False))
@@ -900,6 +1085,12 @@ class MultiPolygonTestCase(unittest.TestCase):
     def test_dumps_4d(self):
         self.assertEqual(self.mpoly4d_wkb,
                          wkb.dumps(self.mpoly4d, big_endian=False))
+
+    def test_dumps_2d_srid4326(self):
+        self.assertEqual(
+            self.mpoly2d_srid4326_wkb,
+            wkb.dumps(self.mpoly2d_srid4326, big_endian=False),
+        )
 
     def test_loads_2d(self):
         self.assertEqual(self.mpoly2d, wkb.loads(self.mpoly2d_wkb))
@@ -977,6 +1168,12 @@ class MultiPolygonTestCase(unittest.TestCase):
 
     def test_loads_zm(self):
         self.assertEqual(self.mpoly4d, wkb.loads(self.mpoly4d_wkb))
+
+    def test_loads_2d_srid4326(self):
+        self.assertEqual(
+            self.mpoly2d_srid4326,
+            wkb.loads(self.mpoly2d_srid4326_wkb),
+        )
 
 
 class GeometryCollectionTestCase(unittest.TestCase):
@@ -1076,7 +1273,8 @@ class GeometryCollectionTestCase(unittest.TestCase):
                     [102.0, 2.0], [103.0, 3.0], [104.0, 4.0]
                 ]),
             ],
-            meta=dict(srid='1234'),
+            meta=dict(srid=1234),
+            crs={'properties': {'name': 'EPSG1234'}, 'type': 'name'},
         )
 
         self.gc2d_srid1234_wkb = (

--- a/geomet/tests/wkb_test.py
+++ b/geomet/tests/wkb_test.py
@@ -90,6 +90,12 @@ class PointTestCase(unittest.TestCase):
     def test_dumps_4d(self):
         self.assertEqual(self.pt4d_wkb, wkb.dumps(self.pt4d, big_endian=False))
 
+    def test_dumps_2d_srid4326(self):
+        self.assertEqual(
+            self.pt2d_srid4326_wkb,
+            wkb.dumps(self.pt2d_srid4326, big_endian=False),
+        )
+
     def test_loads_2d(self):
         self.assertEqual(self.pt2d, wkb.loads(self.pt2d_wkb))
 
@@ -314,6 +320,47 @@ class PolygonTestCase(unittest.TestCase):
             b'\x00\x00\x00\x00\x00\x00\x00\x00'  # 0.0
         )
 
+        self.poly2d_srid26918 = dict(
+            type='Polygon',
+            coordinates=[
+                [[100.001, 0.001], [101.12345, 0.001], [101.001, 1.001],
+                 [100.001, 0.001]],
+                [[100.201, 0.201], [100.801, 0.201], [100.801, 0.801],
+                 [100.201, 0.201]],
+            ],
+            meta=dict(srid='26918'),
+        )
+
+        self.poly2d_srid26918_wkb = (
+            b'\x00'  # big endian
+            b'\x20\x00\x00\x03'  # type, with SRID flag set (0x20)
+            b'\x00\x00\x69\x26'  # 4 bytes containing SRID (SRID=26918)
+            # number of rings, 4 byte int
+            b'\x00\x00\x00\x02'
+            # number of verts in ring (4)
+            b'\x00\x00\x00\x04'
+            # coords
+            b'@Y\x00\x10bM\xd2\xf2'     # 100.001
+            b'?PbM\xd2\xf1\xa9\xfc'     # 0.001
+            b'@YG\xe6\x9a\xd4,='        # 101.12345
+            b'?PbM\xd2\xf1\xa9\xfc'     # 0.001
+            b'@Y@\x10bM\xd2\xf2'        # 101.001
+            b'?\xf0\x04\x18\x93t\xbcj'  # 1.001
+            b'@Y\x00\x10bM\xd2\xf2'     # 100.001
+            b'?PbM\xd2\xf1\xa9\xfc'     # 0.001
+            # number of verts in ring (4)
+            b'\x00\x00\x00\x04'
+            # coords
+            b'@Y\x0c\xdd/\x1a\x9f\xbe'     # 100.201
+            b'?\xc9\xba^5?|\xee'           # 0.201
+            b'@Y3C\x95\x81\x06%'           # 100.801
+            b'?\xc9\xba^5?|\xee'           # 0.201
+            b'@Y3C\x95\x81\x06%'           # 100.801
+            b'?\xe9\xa1\xca\xc0\x83\x12o'  # 0.801
+            b'@Y\x0c\xdd/\x1a\x9f\xbe'     # 100.201
+            b'?\xc9\xba^5?|\xee'           # 0.201
+        )
+
     def test_dumps_2d(self):
         self.assertEqual(self.poly2d_wkb, wkb.dumps(self.poly2d))
 
@@ -342,6 +389,11 @@ class PolygonTestCase(unittest.TestCase):
 
     def test_loads_zm(self):
         self.assertEqual(self.poly4d, wkb.loads(self.poly4d_wkb))
+
+    def test_loads_2d_srid26918(self):
+        self.assertEqual(
+            self.poly2d_srid26918, wkb.loads(self.poly2d_srid26918_wkb)
+        )
 
 
 class MultiPointTestCase(unittest.TestCase):
@@ -1016,6 +1068,37 @@ class GeometryCollectionTestCase(unittest.TestCase):
             b'@(\x00\x00\x00\x00\x00\x00'
         )
 
+        self.gc2d_srid1234 = dict(
+            type='GeometryCollection',
+            geometries=[
+                dict(type='Point', coordinates=[0.0, 1.0]),
+                dict(type='LineString', coordinates=[
+                    [102.0, 2.0], [103.0, 3.0], [104.0, 4.0]
+                ]),
+            ],
+            meta=dict(srid='1234'),
+        )
+
+        self.gc2d_srid1234_wkb = (
+            b'\x00'  # big endian
+            b'\x20\x00\x00\x07'  # 2d geometry collection
+            b'\x00\x00\x04\xd2'  # srid 1234
+            b'\x00\x00\x00\x02'  # 2 geometries in the collection
+            b'\x00'  # big endian
+            b'\x00\x00\x00\x01'  # 2d point
+            b'\x00\x00\x00\x00\x00\x00\x00\x00'
+            b'?\xf0\x00\x00\x00\x00\x00\x00'
+            b'\x00'  # big endian
+            b'\x00\x00\x00\x02'  # 2d linestring
+            b'\x00\x00\x00\x03'  # 3 vertices
+            b'@Y\x80\x00\x00\x00\x00\x00'
+            b'@\x00\x00\x00\x00\x00\x00\x00'
+            b'@Y\xc0\x00\x00\x00\x00\x00'
+            b'@\x08\x00\x00\x00\x00\x00\x00'
+            b'@Z\x00\x00\x00\x00\x00\x00'
+            b'@\x10\x00\x00\x00\x00\x00\x00'
+        )
+
     def test_dumps_2d(self):
         self.assertEqual(self.gc2d_wkb, wkb.dumps(self.gc2d))
 
@@ -1024,6 +1107,9 @@ class GeometryCollectionTestCase(unittest.TestCase):
 
     def test_dumps_4d(self):
         self.assertEqual(self.gc4d_wkb, wkb.dumps(self.gc4d))
+
+    def test_dumps_2d_srid1234(self):
+        self.assertEqual(self.gc2d_srid1234_wkb, wkb.dumps(self.gc2d_srid1234))
 
     def test_loads_2d(self):
         self.assertEqual(self.gc2d, wkb.loads(self.gc2d_wkb))
@@ -1065,3 +1151,6 @@ class GeometryCollectionTestCase(unittest.TestCase):
 
     def test_loads_zm(self):
         self.assertEqual(self.gc4d, wkb.loads(self.gc4d_wkb))
+
+    def test_loads_2d_srid1234(self):
+        self.assertEqual(self.gc2d_srid1234, wkb.loads(self.gc2d_srid1234_wkb))

--- a/geomet/wkb.py
+++ b/geomet/wkb.py
@@ -27,6 +27,9 @@ BIG_ENDIAN = b'\x00'
 #: '\x01': The first byte of any WKB string. Indicates little endian byte
 #: ordering for the data.
 LITTLE_ENDIAN = b'\x01'
+#: High byte in a 4-byte geometry type field to indicate that a 4-byte SRID
+#: field follows.
+SRID_FLAG = b'\x20'
 
 #: Mapping of GeoJSON geometry types to the "2D" 4-byte binary string
 #: representation for WKB. "2D" indicates that the geometry is 2-dimensional,
@@ -109,20 +112,39 @@ def _get_geom_type(type_bytes):
 
     :param type_bytes:
         4 byte string in big endian byte order containing a WKB type number.
+        It may also contain a "has SRID" flag in the high byte (the first type,
+        since this is big endian byte order), indicated as 0x20. If the SRID
+        flag is not set, the high byte will always be null (0x00).
     :returns:
-        GeoJSON geometry type label. For example:
+        3-tuple ofGeoJSON geometry type label, the bytes resprenting the
+        geometry type, and a separate "has SRID" flag. If the input
+        `type_bytes` contains an SRID flag, it will be removed.
 
-        >>> # Z Point
-        >>> _get_geom_type(b'\\x00\\x00\\x03\\xe9')
-        'Point'
+        >>> # Z Point, with SRID flag
+        >>> _get_geom_type(b'\\x20\\x00\\x03\\xe9') == (
+        ... 'Point', b'\\x00\\x00\\x03\\xe9', True)
+        True
 
-        >>> # 2D MultiLineString
-        >>> _get_geom_type(b'\\x00\\x00\\x00\\x05')
-        'MultiLineString'
+        >>> # 2D MultiLineString, without SRID flag
+        >>> _get_geom_type(b'\\x00\\x00\\x00\\x05') == (
+        ... 'MultiLineString', b'\\x00\\x00\\x00\\x05', False)
+        True
 
     """
+    # slice off the high byte, which may contain the SRID flag
+    high_byte = type_bytes[0]
+    if six.PY3:
+        high_byte = bytes([high_byte])
+    has_srid = high_byte == b'\x20'
+    if has_srid:
+        # replace the high byte with a null byte
+        type_bytes = as_bin_str(b'\x00' + type_bytes[1:])
+    else:
+        type_bytes = as_bin_str(type_bytes)
+
+    # look up the geometry type
     geom_type = _BINARY_TO_GEOM_TYPE.get(type_bytes)
-    return geom_type
+    return geom_type, type_bytes, has_srid
 
 
 def dump(obj, dest_file):
@@ -190,6 +212,9 @@ def dumps(obj, big_endian=True):
     :param bool big_endian:
         Defaults to `True`. If `True`, data values in the generated WKB will
         be represented using big endian byte order. Else, little endian.
+
+    TODO: remove this
+
     :param str dims:
         Indicates to WKB representation desired from converting the given
         GeoJSON `dict` ``obj``. The accepted values are:
@@ -203,6 +228,7 @@ def dumps(obj, big_endian=True):
         A WKB binary string representing of the ``obj``.
     """
     geom_type = obj['type']
+    meta = obj.get('meta', {})
 
     exporter = _dumps_registry.get(geom_type)
     if exporter is None:
@@ -217,13 +243,49 @@ def dumps(obj, big_endian=True):
             'dimensionality of the WKB would be ambiguous.'
         )
 
-    return exporter(obj, big_endian)
+    return exporter(obj, big_endian, meta)
 
 
 def loads(string):
     """
-    Construct a GeoJson `dict` from WKB (`string`).
-    """
+    Construct a GeoJSON `dict` from WKB (`string`).
+
+    The resulting GeoJSON `dict` will include the SRID as an integer in the
+    `meta` object. This was an arbitrary decision made by `geomet, the
+    discussion of which took place here:
+    https://github.com/geomet/geomet/issues/28.
+
+    In order to be consistent with other libraries [1] and (deprecated)
+    specifications [2], also include the same information in a `crs`
+    object. This isn't ideal, but the `crs` member is no longer part of
+    the GeoJSON standard, according to RFC7946 [3]. However, it's still
+    useful to include this information in GeoJSON payloads because it
+    supports conversion to EWKT/EWKB (which are canonical formats used by
+    PostGIS and the like).
+
+    Example:
+
+        {'type': 'Point',
+         'coordinates': [0.0, 1.0],
+         'meta': {'srid': 4326},
+         'crs': {'type': 'name', 'properties': {'name': 'EPSG4326'}}}
+
+    NOTE(larsbutler): I'm not sure if it's valid to just prefix EPSG
+    (European Petroluem Survey Group) to an SRID like this, but we'll
+    stick with it for now until it becomes a problem.
+
+    NOTE(larsbutler): Ideally, we should use URNs instead of this
+    notation, according to the new GeoJSON spec [4]. However, in
+    order to be consistent with [1], we'll stick with this approach
+    for now.
+
+    References:
+
+    [1] - https://github.com/bryanjos/geo/issues/76
+    [2] - http://geojson.org/geojson-spec.html#coordinate-reference-system-objects
+    [3] - https://tools.ietf.org/html/rfc7946#appendix-B.1
+    [4] - https://tools.ietf.org/html/rfc7946#section-4
+    """  # noqa
     string = iter(string)
     # endianness = string[0:1]
     endianness = as_bin_str(take(1, string))
@@ -235,13 +297,19 @@ def loads(string):
         raise ValueError("Invalid endian byte: '0x%s'. Expected 0x00 or 0x01"
                          % binascii.hexlify(endianness.encode()).decode())
 
+    endian_token = '>' if big_endian else '<'
     # type_bytes = string[1:5]
     type_bytes = as_bin_str(take(4, string))
     if not big_endian:
         # To identify the type, order the type bytes in big endian:
         type_bytes = type_bytes[::-1]
 
-    geom_type = _get_geom_type(type_bytes)
+    geom_type, type_bytes, has_srid = _get_geom_type(type_bytes)
+    srid = None
+    if has_srid:
+        srid_field = as_bin_str(take(4, string))
+        [srid] = struct.unpack('%si' % endian_token, srid_field)
+
     # data_bytes = string[5:]  # FIXME: This won't work for GeometryCollections
     data_bytes = string
 
@@ -251,14 +319,24 @@ def loads(string):
         _unsupported_geom_type(geom_type)
 
     data_bytes = iter(data_bytes)
-    return importer(big_endian, type_bytes, data_bytes)
+    result = importer(big_endian, type_bytes, data_bytes)
+    if has_srid:
+        # As mentioned in the docstring above, include both approaches to
+        # indicating the SRID.
+        result['meta'] = {'srid': int(srid)}
+        result['crs'] = {
+            'type': 'name',
+            'properties': {'name': 'EPSG%s' % srid},
+        }
+    return result
 
 
 def _unsupported_geom_type(geom_type):
     raise ValueError("Unsupported geometry type '%s'" % geom_type)
 
 
-def _header_bytefmt_byteorder(geom_type, num_dims, big_endian):
+# TODO: dont default meta to none
+def _header_bytefmt_byteorder(geom_type, num_dims, big_endian, meta=None):
     """
     Utility function to get the WKB header (endian byte + type header), byte
     format string, and byte order string.
@@ -268,6 +346,10 @@ def _header_bytefmt_byteorder(geom_type, num_dims, big_endian):
         pass  # TODO: raise
 
     type_byte_str = _WKB[dim][geom_type]
+    srid = meta.get('srid')
+    if srid is not None:
+        # Add the srid flag
+        type_byte_str = SRID_FLAG + type_byte_str[1:]
 
     if big_endian:
         header = BIG_ENDIAN
@@ -281,12 +363,20 @@ def _header_bytefmt_byteorder(geom_type, num_dims, big_endian):
         type_byte_str = type_byte_str[::-1]
 
     header += type_byte_str
+    if srid is not None:
+        srid = int(srid)
+
+        if big_endian:
+            srid_header = struct.pack('>i', srid)
+        else:
+            srid_header = struct.pack('<i', srid)
+        header += srid_header
     byte_fmt += b'd' * num_dims
 
     return header, byte_fmt, byte_order
 
 
-def _dump_point(obj, big_endian):
+def _dump_point(obj, big_endian, meta):
     """
     Dump a GeoJSON-like `dict` to a point WKB string.
 
@@ -295,6 +385,17 @@ def _dump_point(obj, big_endian):
     :param bool big_endian:
         If `True`, data values in the generated WKB will be represented using
         big endian byte order. Else, little endian.
+    :param dict meta:
+        Metadata associated with the GeoJSON object. Currently supported
+        metadata:
+
+        - srid: Used to support EWKT/EWKB. For example, ``meta`` equal to
+          ``{'srid': '4326'}`` indicates that the geometry is defined using
+          Extended WKT/WKB and that it bears a Spatial Reference System
+          Identifier of 4326. This ID will be encoded into the resulting
+          binary.
+
+        Any other meta data objects will simply be ignored by this function.
 
     :returns:
         A WKB binary string representing of the Point ``obj``.
@@ -303,14 +404,14 @@ def _dump_point(obj, big_endian):
     num_dims = len(coords)
 
     wkb_string, byte_fmt, _ = _header_bytefmt_byteorder(
-        'Point', num_dims, big_endian
+        'Point', num_dims, big_endian, meta
     )
 
     wkb_string += struct.pack(byte_fmt, *coords)
     return wkb_string
 
 
-def _dump_linestring(obj, big_endian):
+def _dump_linestring(obj, big_endian, meta):
     """
     Dump a GeoJSON-like `dict` to a linestring WKB string.
 
@@ -322,7 +423,7 @@ def _dump_linestring(obj, big_endian):
     num_dims = len(vertex)
 
     wkb_string, byte_fmt, byte_order = _header_bytefmt_byteorder(
-        'LineString', num_dims, big_endian
+        'LineString', num_dims, big_endian, meta
     )
     # append number of vertices in linestring
     wkb_string += struct.pack('%sl' % byte_order, len(coords))
@@ -333,7 +434,7 @@ def _dump_linestring(obj, big_endian):
     return wkb_string
 
 
-def _dump_polygon(obj, big_endian):
+def _dump_polygon(obj, big_endian, meta):
     """
     Dump a GeoJSON-like `dict` to a polygon WKB string.
 
@@ -345,7 +446,7 @@ def _dump_polygon(obj, big_endian):
     num_dims = len(vertex)
 
     wkb_string, byte_fmt, byte_order = _header_bytefmt_byteorder(
-        'Polygon', num_dims, big_endian
+        'Polygon', num_dims, big_endian, meta
     )
 
     # number of rings:
@@ -359,7 +460,7 @@ def _dump_polygon(obj, big_endian):
     return wkb_string
 
 
-def _dump_multipoint(obj, big_endian):
+def _dump_multipoint(obj, big_endian, meta):
     """
     Dump a GeoJSON-like `dict` to a multipoint WKB string.
 
@@ -370,7 +471,7 @@ def _dump_multipoint(obj, big_endian):
     num_dims = len(vertex)
 
     wkb_string, byte_fmt, byte_order = _header_bytefmt_byteorder(
-        'MultiPoint', num_dims, big_endian
+        'MultiPoint', num_dims, big_endian, meta
     )
 
     point_type = _WKB[_INT_TO_DIM_LABEL.get(num_dims)]['Point']
@@ -388,7 +489,7 @@ def _dump_multipoint(obj, big_endian):
     return wkb_string
 
 
-def _dump_multilinestring(obj, big_endian):
+def _dump_multilinestring(obj, big_endian, meta):
     """
     Dump a GeoJSON-like `dict` to a multilinestring WKB string.
 
@@ -399,7 +500,7 @@ def _dump_multilinestring(obj, big_endian):
     num_dims = len(vertex)
 
     wkb_string, byte_fmt, byte_order = _header_bytefmt_byteorder(
-        'MultiLineString', num_dims, big_endian
+        'MultiLineString', num_dims, big_endian, meta
     )
 
     ls_type = _WKB[_INT_TO_DIM_LABEL.get(num_dims)]['LineString']
@@ -421,7 +522,7 @@ def _dump_multilinestring(obj, big_endian):
     return wkb_string
 
 
-def _dump_multipolygon(obj, big_endian):
+def _dump_multipolygon(obj, big_endian, meta):
     """
     Dump a GeoJSON-like `dict` to a multipolygon WKB string.
 
@@ -432,7 +533,7 @@ def _dump_multipolygon(obj, big_endian):
     num_dims = len(vertex)
 
     wkb_string, byte_fmt, byte_order = _header_bytefmt_byteorder(
-        'MultiPolygon', num_dims, big_endian
+        'MultiPolygon', num_dims, big_endian, meta
     )
 
     poly_type = _WKB[_INT_TO_DIM_LABEL.get(num_dims)]['Polygon']
@@ -458,7 +559,7 @@ def _dump_multipolygon(obj, big_endian):
     return wkb_string
 
 
-def _dump_geometrycollection(obj, big_endian):
+def _dump_geometrycollection(obj, big_endian, meta):
     # TODO: handle empty collections
     geoms = obj['geometries']
     # determine the dimensionality (2d, 3d, 4d) of the collection
@@ -479,7 +580,7 @@ def _dump_geometrycollection(obj, big_endian):
         num_dims = 4
 
     wkb_string, byte_fmt, byte_order = _header_bytefmt_byteorder(
-        'GeometryCollection', num_dims, big_endian
+        'GeometryCollection', num_dims, big_endian, meta
     )
     # append the number of geometries
     wkb_string += struct.pack('%sl' % byte_order, len(geoms))

--- a/geomet/wkb.py
+++ b/geomet/wkb.py
@@ -104,6 +104,27 @@ _BINARY_TO_GEOM_TYPE = dict(
 _INT_TO_DIM_LABEL = {2: '2D', 3: 'Z', 4: 'ZM'}
 
 
+def _get_geom_type(type_bytes):
+    """Get the GeoJSON geometry type label from a WKB type byte string.
+
+    :param type_bytes:
+        4 byte string in big endian byte order containing a WKB type number.
+    :returns:
+        GeoJSON geometry type label. For example:
+
+        >>> # Z Point
+        >>> _get_geom_type(b'\\x00\\x00\\x03\\xe9')
+        'Point'
+
+        >>> # 2D MultiLineString
+        >>> _get_geom_type(b'\\x00\\x00\\x00\\x05')
+        'MultiLineString'
+
+    """
+    geom_type = _BINARY_TO_GEOM_TYPE.get(type_bytes)
+    return geom_type
+
+
 def dump(obj, dest_file):
     """
     Dump GeoJSON-like `dict` to WKB and write it to the `dest_file`.
@@ -220,7 +241,7 @@ def loads(string):
         # To identify the type, order the type bytes in big endian:
         type_bytes = type_bytes[::-1]
 
-    geom_type = _BINARY_TO_GEOM_TYPE.get(type_bytes)
+    geom_type = _get_geom_type(type_bytes)
     # data_bytes = string[5:]  # FIXME: This won't work for GeometryCollections
     data_bytes = string
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,py33,py34,py35,py36,flake8
+envlist = py27,py33,py34,py35,py36,style
 
 [testenv]
 install_command = pip install -U {opts} {packages}
@@ -9,7 +9,7 @@ deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
 commands = nosetests {posargs} --with-doctest --with-coverage --cover-package=geomet
 
-[testenv:flake8]
+[testenv:style]
 commands = flake8 geomet
 
 [testenv:venv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,py33,py34,py35,flake8
+envlist = py27,py33,py34,py35,py36,flake8
 
 [testenv]
 install_command = pip install -U {opts} {packages}


### PR DESCRIPTION
This branch adds support for Extended Well-Known Text/Binary. EWKT and EWKB are commonly used, particularly by PostGIS.

This branch addresses #28 and #31. With the support of EWKT/EWKB, https://github.com/geoalchemy/geoalchemy2/issues/155 should work now.

This change required the invention of some optional non-standard metadata additions to GeoJSON in order to preserve the SRID. Here's an example:

```json
{
  "type": "Point",
  "coordinates": [0.0, 1.0],
  "meta": {
    "srid": "4326",
  },
  "crs": {
    "properties": {"name": "EPSG4326"}, "type": "name"}
  }
}
```

The metadata was discussed at length in https://github.com/geomet/geomet/issues/28. I ultimately opted to go with `'meta': {'srid': '4326'}` instead of just `'srid': '4326'` because the former is more general and extensible.

Update: In order to be compatible with a similar library for Elixir [1] and the original (now obsolete) GeoJSON spec [2], I have opted to include a `crs` object in the GeoJSON output as well. The RFC which replaced the original GeoJSON spec makes obsolete the `crs` member [3], but doesn't offer a alternative. Instead, the RFC standardizes on WGS84 (aka, EPSG4326) [4]. This is sensible, but unfortunately it doesn't help in cases where the SRID must be explicitly preserved throughout conversions--hence the reason why this feature is being added to `geomet`.

Adding the `crs` object maintains some consistency with previous work; however, the `meta.srid` will stay so that you don't have strip off the leading `EPSG` in order to get to the SRID value, which makes reading payloads less of a hassle. I hope that makes sense.

References:
[1] - https://github.com/bryanjos/geo/issues/76
[2] - http://geojson.org/geojson-spec.html#coordinate-reference-system-objects
[3] - https://tools.ietf.org/html/rfc7946#appendix-B.1
[4] - https://tools.ietf.org/html/rfc7946#section-4

TODO before merging:
- [x] add README docs to explain support for EWKT/EWKB and give some examples