### PR TITLE
setup.py: fix package definition issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,9 @@ setup(
     platforms=['any'],
     packages=find_packages(exclude=['geomet.tests', 'geomet.tests.*']),
     entry_points={'console_scripts': ['geomet=geomet.tool:cli']},
-    provides=['geomet (%s)' % VERSION],
     license='Apache 2.0',
     keywords='wkb wkt geojson',
-    classifiers=(
+    classifiers=[
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: Apache Software License',
         'Intended Audience :: Developers',
@@ -53,7 +52,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Topic :: Scientific/Engineering :: GIS',
-    ),
+    ],
     zip_safe=False,
     install_requires=['click', 'six'],
 )


### PR DESCRIPTION
- Don't use `provides`. This isn't officially supported and technically
  provides the same information as `name` and `version` (which are
  already present.
- Make classifiers a list rather than a tuple. For some reason this
  worked last time a package was published, but not setuptools complains
  with a strange message about invalid classifiers.

(These were preventing PyPI package uploads.)