### PR TITLE
Use round function to handle coordinate truncation over string formatting.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -3,3 +3,4 @@
 Lars Butler <lars.butler@gmail.com> - March 2013
 Maralla <maralla.ai@gmail.com> - November 2013
 Sean Gillies <sean.gillies@gmail.com> - August 2014
+Tom Caruso <carusot42@gmail.com> - December 2018

--- a/geomet/tests/wkt_test.py
+++ b/geomet/tests/wkt_test.py
@@ -962,3 +962,15 @@ class GeometryCollectionLoadsTestCase(unittest.TestCase):
             'meta': dict(srid=662),
         }
         self.assertEqual(expected, wkt.loads(gc))
+
+
+class TestRoundAndPad(unittest.TestCase):
+    def test(self):
+        test_cases = [
+            [(-1.000000000000000, 16), '-1.' + '0' * 16],
+            [(-83.2496395, 16), '-83.2496395000000000'],
+            [(35.917330500000006, 16), '35.9173305000000060']
+        ]
+
+        for args, expected in test_cases:
+            self.assertEqual(expected, wkt._round_and_pad(*args))

--- a/geomet/wkt.py
+++ b/geomet/wkt.py
@@ -181,7 +181,7 @@ def _round_and_pad(value, decimals):
     :param value:
         The value to round
     :param decimals:
-        Number of places to round to
+        Number of decimals places which should be displayed after the rounding.
     :return:
         str of the rounded value
     """
@@ -204,8 +204,8 @@ def _dump_point(obj, decimals):
 
     :param dict obj:
         A GeoJSON-like `dict` representing a Point.
-    :param str fmt:
-        Format string which indicates the number of digits to display after the
+    :param int decimals:
+        int which indicates the number of digits to display after the
         decimal point when formatting coordinates.
 
     :returns:

--- a/geomet/wkt.py
+++ b/geomet/wkt.py
@@ -176,7 +176,8 @@ def _unsupported_geom_type(geom_type):
 
 def _round_and_pad(value, decimals):
     """
-    Round the input value to `decimals` places, and pad with 0's if the resulting value is less than `decimals`.
+    Round the input value to `decimals` places, and pad with 0's
+    if the resulting value is less than `decimals`.
 
     :param value:
         The value to round
@@ -186,7 +187,8 @@ def _round_and_pad(value, decimals):
         str of the rounded value
     """
     if isinstance(value, int) and decimals != 0:
-        # if we get an int coordinate and we have a non-zero value for `decimals`, we want to create a float to pad out.
+        # if we get an int coordinate and we have a non-zero value for
+        # `decimals`, we want to create a float to pad out.
         value = float(value)
 
     elif decimals == 0:
@@ -212,7 +214,8 @@ def _dump_point(obj, decimals):
         WKT representation of the input GeoJSON Point ``obj``.
     """
     coords = obj['coordinates']
-    pt = 'POINT (%s)' % ' '.join(_round_and_pad(c, decimals) for c in coords)
+    pt = 'POINT (%s)' % ' '.join(_round_and_pad(c, decimals)
+                                 for c in coords)
     return pt
 
 
@@ -225,7 +228,8 @@ def _dump_linestring(obj, decimals):
     """
     coords = obj['coordinates']
     ls = 'LINESTRING (%s)'
-    ls %= ', '.join(' '.join(_round_and_pad(c, decimals) for c in pt) for pt in coords)
+    ls %= ', '.join(' '.join(_round_and_pad(c, decimals)
+                             for c in pt) for pt in coords)
     return ls
 
 
@@ -238,7 +242,8 @@ def _dump_polygon(obj, decimals):
     """
     coords = obj['coordinates']
     poly = 'POLYGON (%s)'
-    rings = (', '.join(' '.join(_round_and_pad(c, decimals) for c in pt) for pt in ring)
+    rings = (', '.join(' '.join(_round_and_pad(c, decimals)
+                                for c in pt) for pt in ring)
              for ring in coords)
     rings = ('(%s)' % r for r in rings)
     poly %= ', '.join(rings)
@@ -254,7 +259,8 @@ def _dump_multipoint(obj, decimals):
     """
     coords = obj['coordinates']
     mp = 'MULTIPOINT (%s)'
-    points = (' '.join(_round_and_pad(c, decimals) for c in pt) for pt in coords)
+    points = (' '.join(_round_and_pad(c, decimals)
+                       for c in pt) for pt in coords)
     # Add parens around each point.
     points = ('(%s)' % pt for pt in points)
     mp %= ', '.join(points)
@@ -270,8 +276,8 @@ def _dump_multilinestring(obj, decimals):
     """
     coords = obj['coordinates']
     mlls = 'MULTILINESTRING (%s)'
-    linestrs = ('(%s)' % ', '.join(' '.join(_round_and_pad(c, decimals) for c in pt)
-                for pt in linestr) for linestr in coords)
+    linestrs = ('(%s)' % ', '.join(' '.join(_round_and_pad(c, decimals)
+                for c in pt) for pt in linestr) for linestr in coords)
     mlls %= ', '.join(ls for ls in linestrs)
     return mlls
 

--- a/geomet/wkt.py
+++ b/geomet/wkt.py
@@ -76,8 +76,7 @@ def dumps(obj, decimals=16):
     except KeyError:
         raise geomet.InvalidGeoJSONException('Invalid GeoJSON: %s' % obj)
 
-    fmt = '%%.%df' % decimals
-    result = exporter(obj, fmt)
+    result = exporter(obj, decimals)
     # Try to get the SRID from `meta.srid`
     meta_srid = obj.get('meta', {}).get('srid')
     # Also try to get it from `crs.properties.name`:
@@ -175,7 +174,31 @@ def _unsupported_geom_type(geom_type):
     raise ValueError("Unsupported geometry type '%s'" % geom_type)
 
 
-def _dump_point(obj, fmt):
+def _round_and_pad(value, decimals):
+    """
+    Round the input value to `decimals` places, and pad with 0's if the resulting value is less than `decimals`.
+
+    :param value:
+        The value to round
+    :param decimals:
+        Number of places to round to
+    :return:
+        str of the rounded value
+    """
+    if isinstance(value, int) and decimals != 0:
+        # if we get an int coordinate and we have a non-zero value for `decimals`, we want to create a float to pad out.
+        value = float(value)
+
+    elif decimals == 0:
+        # if get a `decimals` value of 0, we want to return an int.
+        return str(int(round(value, decimals)))
+
+    rounded = str(round(value, decimals))
+    rounded += '0' * (decimals - len(rounded.split('.')[1]))
+    return rounded
+
+
+def _dump_point(obj, decimals):
     """
     Dump a GeoJSON-like Point object to WKT.
 
@@ -189,11 +212,11 @@ def _dump_point(obj, fmt):
         WKT representation of the input GeoJSON Point ``obj``.
     """
     coords = obj['coordinates']
-    pt = 'POINT (%s)' % ' '.join(fmt % c for c in coords)
+    pt = 'POINT (%s)' % ' '.join(_round_and_pad(c, decimals) for c in coords)
     return pt
 
 
-def _dump_linestring(obj, fmt):
+def _dump_linestring(obj, decimals):
     """
     Dump a GeoJSON-like LineString object to WKT.
 
@@ -202,11 +225,11 @@ def _dump_linestring(obj, fmt):
     """
     coords = obj['coordinates']
     ls = 'LINESTRING (%s)'
-    ls %= ', '.join(' '.join(fmt % c for c in pt) for pt in coords)
+    ls %= ', '.join(' '.join(_round_and_pad(c, decimals) for c in pt) for pt in coords)
     return ls
 
 
-def _dump_polygon(obj, fmt):
+def _dump_polygon(obj, decimals):
     """
     Dump a GeoJSON-like Polygon object to WKT.
 
@@ -215,14 +238,14 @@ def _dump_polygon(obj, fmt):
     """
     coords = obj['coordinates']
     poly = 'POLYGON (%s)'
-    rings = (', '.join(' '.join(fmt % c for c in pt) for pt in ring)
+    rings = (', '.join(' '.join(_round_and_pad(c, decimals) for c in pt) for pt in ring)
              for ring in coords)
     rings = ('(%s)' % r for r in rings)
     poly %= ', '.join(rings)
     return poly
 
 
-def _dump_multipoint(obj, fmt):
+def _dump_multipoint(obj, decimals):
     """
     Dump a GeoJSON-like MultiPoint object to WKT.
 
@@ -231,14 +254,14 @@ def _dump_multipoint(obj, fmt):
     """
     coords = obj['coordinates']
     mp = 'MULTIPOINT (%s)'
-    points = (' '.join(fmt % c for c in pt) for pt in coords)
+    points = (' '.join(_round_and_pad(c, decimals) for c in pt) for pt in coords)
     # Add parens around each point.
     points = ('(%s)' % pt for pt in points)
     mp %= ', '.join(points)
     return mp
 
 
-def _dump_multilinestring(obj, fmt):
+def _dump_multilinestring(obj, decimals):
     """
     Dump a GeoJSON-like MultiLineString object to WKT.
 
@@ -247,13 +270,13 @@ def _dump_multilinestring(obj, fmt):
     """
     coords = obj['coordinates']
     mlls = 'MULTILINESTRING (%s)'
-    linestrs = ('(%s)' % ', '.join(' '.join(fmt % c for c in pt)
+    linestrs = ('(%s)' % ', '.join(' '.join(_round_and_pad(c, decimals) for c in pt)
                 for pt in linestr) for linestr in coords)
     mlls %= ', '.join(ls for ls in linestrs)
     return mlls
 
 
-def _dump_multipolygon(obj, fmt):
+def _dump_multipolygon(obj, decimals):
     """
     Dump a GeoJSON-like MultiPolygon object to WKT.
 
@@ -273,7 +296,7 @@ def _dump_multipolygon(obj, fmt):
                 # and wrap in parens
                 '(%s)' % ', '.join(
                     # join coordinate values of a vertex
-                    ' '.join(fmt % c for c in pt)
+                    ' '.join(_round_and_pad(c, decimals) for c in pt)
                     for pt in ring)
                 for ring in poly)
             for poly in coords)
@@ -282,7 +305,7 @@ def _dump_multipolygon(obj, fmt):
     return mp
 
 
-def _dump_geometrycollection(obj, fmt):
+def _dump_geometrycollection(obj, decimals):
     """
     Dump a GeoJSON-like GeometryCollection object to WKT.
 
@@ -297,7 +320,7 @@ def _dump_geometrycollection(obj, fmt):
     geoms_wkt = []
     for geom in geoms:
         geom_type = geom['type']
-        geoms_wkt.append(_dumps_registry.get(geom_type)(geom, fmt))
+        geoms_wkt.append(_dumps_registry.get(geom_type)(geom, decimals))
     gc %= ','.join(geoms_wkt)
     return gc
 

--- a/geomet/wkt.py
+++ b/geomet/wkt.py
@@ -193,9 +193,9 @@ def _round_and_pad(value, decimals):
 
     elif decimals == 0:
         # if get a `decimals` value of 0, we want to return an int.
-        return str(int(round(value, decimals)))
+        return repr(int(round(value, decimals)))
 
-    rounded = str(round(value, decimals))
+    rounded = repr(round(value, decimals))
     rounded += '0' * (decimals - len(rounded.split('.')[1]))
     return rounded
 


### PR DESCRIPTION
## What does this pull request accomplish?

This PR attempts to solve the problem raised in [this issue](https://github.com/geomet/geomet/issues/38), by leveraging Python's builtin `round` function to round coordinates to the appropriate decimal place instead of using string formatting, which leads to precision issues in specific cases, as outlined in the linked issue.

## Main changes

The main focus of this PR is a new `_round_and_pad` function, which will take a value and a decimal number and round the input value to the given decimal, returning the resulting number as a string, right padded with zeros to the appropriate decimal place. In the case where `decimals=0` it will round the input value up and return it as an `int`. When the input is an `int`, it will simply cast to a `float` and pad with 0's.

As a result of this change, all of the wkt `_dump_*` functions needed to be altered to take as input a decimals parameter. Each function now calls the `_round_and_pad` function for each coordinate value instead of using the `fmt` format string to truncate the value.

Tests were added for the `_round_and_pad` function, and all existing tests pass after this change. Which, by the way, your test suite was very thorough and helpful in demonstrating the correct behavior in those special cases of `decimals=0` and an input`int`. 

I added the example in the linked issue as test cases for the `_round_and_pad` function to ensure that my specific case would be addressed by this change.

Thanks for reviewing!
Tom