### PR TITLE
Support future 3.x Python versions.

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -4,3 +4,4 @@ Lars Butler <lars.butler@gmail.com> - March 2013
 Maralla <maralla.ai@gmail.com> - November 2013
 Sean Gillies <sean.gillies@gmail.com> - August 2014
 Tom Caruso <carusot42@gmail.com> - December 2018
+Paul Bryan <pbryan@anode.ca> - August 2019

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,10 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Scientific/Engineering :: GIS',
     ],
     zip_safe=False,
     install_requires=['click', 'six'],
-    python_requires=">2.6, !=3.3.*, <3.8",
+    python_requires=">2.6, !=3.3.*, <4",
 )


### PR DESCRIPTION
A dependency management tool like Poetry accepts expressions of dependencies of packages and Python like `^3.4`, which is equivalent to `>=3.4 <4`. A conflict arises when a future 3.x version of Python is prohibited in the `python_requires` parameter in `setup.py`. This change proposes relaxing the constraint on future versions to prevent such conflicts.