### PR TITLE
Remove `data_files` directive from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,6 @@ setup(
     platforms=['any'],
     packages=find_packages(exclude=['geomet.tests', 'geomet.tests.*']),
     entry_points={'console_scripts': ['geomet=geomet.tool:cli']},
-    data_files=[
-        ('', ['LICENSE']),
-    ],
     license='Apache 2.0',
     keywords='wkb wkt geojson',
     classifiers=[


### PR DESCRIPTION
This was intended to include the LICENSE text file in the source
package, as well as install the LICENSE file with the package. However,
it doesn't work like that; instead, the LICENSE was being put in a very
silly location. See
https://github.com/geomet/geomet/pull/44#issuecomment-524531530.

The current packaging approach automatically includes the LICENSE file
in the source package, which satisfies
https://github.com/geomet/geomet/issues/43. The license file included
with the 0.2.0.post2 release and later, but not the 0.2.1 release from
2017.

Fixes #43 and #47.