### PR TITLE
Fix parsing for empty geometries

### DIFF
--- a/geomet/tests/wkt_test.py
+++ b/geomet/tests/wkt_test.py
@@ -880,6 +880,7 @@ class GeometryCollectionDumpsTestCase(unittest.TestCase):
 
         self.assertEqual(expected, wkt.dumps(gc))
 
+
 class GeometryCollectionLoadsTestCase(unittest.TestCase):
 
     def test_basic_gc(self):

--- a/geomet/tests/wkt_test.py
+++ b/geomet/tests/wkt_test.py
@@ -837,16 +837,48 @@ class GeometryCollectionDumpsTestCase(unittest.TestCase):
 
     def test_with_empty_component(self):
         # Example from https://github.com/geomet/geomet/issues/49
-        gc = {'type': 'GeometryCollection', 'geometries': [
-            {'type': 'Polygon', 'coordinates': [
-                [[27.0, 25.0], [102.0, 36.0], [102.0, 46.0], [92.0, 61.0], [13.0, 41.0], [16.0, 30.0], [27.0, 25.0]]]},
-            {'type': 'LineString', 'coordinates': []}
-        ]}
+        gc = {
+            'type': 'GeometryCollection',
+            'geometries': [
+                {'type': 'Polygon', 'coordinates': [
+                    [[27.0, 25.0], [102.0, 36.0], [102.0, 46.0], [92.0, 61.0], [13.0, 41.0], [16.0, 30.0],
+                     [27.0, 25.0]]]},
+                {'type': 'LineString', 'coordinates': []}
+            ]}
 
         expected = 'GEOMETRYCOLLECTION (POLYGON ((27 25, 102 36, 102 46, 92 61, 13 41, 16 30, 27 25)),LINESTRING EMPTY)'
 
         self.assertEqual(expected, wkt.dumps(gc, decimals=0))
 
+    def test_empty_component_with_srid(self):
+        gc = {
+            'type': 'GeometryCollection',
+            'meta': {'srid': 4326},
+            'geometries': [
+                {'type': 'Point', 'coordinates': []}
+            ]
+        }
+
+        expected = 'SRID=4326;GEOMETRYCOLLECTION (POINT EMPTY)'
+
+        self.assertEqual(expected, wkt.dumps(gc))
+
+    def test_all_types_empty(self):
+        gc = {
+            'type': 'GeometryCollection',
+            'geometries': [
+                {'coordinates': [], 'type': 'Point'},
+                {'coordinates': [], 'type': 'LineString'},
+                {'coordinates': [], 'type': 'Polygon'},
+                {'coordinates': [], 'type': 'MultiPoint'},
+                {'coordinates': [], 'type': 'MultiLineString'},
+                {'coordinates': [], 'type': 'MultiPolygon'},
+                {'geometries': [], 'type': 'GeometryCollection'}],
+        }
+
+        expected = 'GEOMETRYCOLLECTION (%s)' % ','.join('%s EMPTY' % typ for typ in wkt._type_map_caps_to_mixed.keys())
+
+        self.assertEqual(expected, wkt.dumps(gc))
 
 class GeometryCollectionLoadsTestCase(unittest.TestCase):
 
@@ -1005,12 +1037,44 @@ class GeometryCollectionLoadsTestCase(unittest.TestCase):
         # Example from https://github.com/geomet/geomet/issues/49
         gc = 'GEOMETRYCOLLECTION (POLYGON((27 25,102 36,102 46,92 61,13 41,16 30,27 25)),LINESTRING EMPTY)'
 
-        expected = {'type': 'GeometryCollection', 'geometries': [
-            {'type': 'Polygon', 'coordinates': [
-                [[27.0, 25.0], [102.0, 36.0], [102.0, 46.0], [92.0, 61.0], [13.0, 41.0], [16.0, 30.0], [27.0, 25.0]]]},
-            {'type': 'LineString', 'coordinates': []}
-        ]}
+        expected = {
+            'type': 'GeometryCollection',
+            'geometries': [
+                {'type': 'Polygon', 'coordinates': [
+                    [[27.0, 25.0], [102.0, 36.0], [102.0, 46.0], [92.0, 61.0], [13.0, 41.0], [16.0, 30.0],
+                     [27.0, 25.0]]]},
+                {'type': 'LineString', 'coordinates': []}
+            ]}
 
+        self.assertEqual(expected, wkt.loads(gc))
+
+    def test_empty_component_with_srid(self):
+        gc = 'SRID=4326;GEOMETRYCOLLECTION (POINT EMPTY)'
+
+        expected = {
+            'type': 'GeometryCollection',
+            'meta': {'srid': 4326},
+            'geometries': [
+                {'type': 'Point', 'coordinates': []}
+            ]
+        }
+
+        self.assertEqual(expected, wkt.loads(gc))
+
+    def test_all_types_empty(self):
+        gc = 'GEOMETRYCOLLECTION (%s)' % ','.join('%s EMPTY' % typ for typ in wkt._type_map_caps_to_mixed.keys())
+
+        expected = {
+            'type': 'GeometryCollection',
+            'geometries': [
+                {'coordinates': [], 'type': 'Point'},
+                {'coordinates': [], 'type': 'LineString'},
+                {'coordinates': [], 'type': 'Polygon'},
+                {'coordinates': [], 'type': 'MultiPoint'},
+                {'coordinates': [], 'type': 'MultiLineString'},
+                {'coordinates': [], 'type': 'MultiPolygon'},
+                {'geometries': [], 'type': 'GeometryCollection'}],
+        }
         self.assertEqual(expected, wkt.loads(gc))
 
 

--- a/geomet/tests/wkt_test.py
+++ b/geomet/tests/wkt_test.py
@@ -867,16 +867,17 @@ class GeometryCollectionDumpsTestCase(unittest.TestCase):
         gc = {
             'type': 'GeometryCollection',
             'geometries': [
-                {'coordinates': [], 'type': 'Point'},
+                {'geometries': [], 'type': 'GeometryCollection'},
                 {'coordinates': [], 'type': 'LineString'},
-                {'coordinates': [], 'type': 'Polygon'},
-                {'coordinates': [], 'type': 'MultiPoint'},
                 {'coordinates': [], 'type': 'MultiLineString'},
+                {'coordinates': [], 'type': 'MultiPoint'},
                 {'coordinates': [], 'type': 'MultiPolygon'},
-                {'geometries': [], 'type': 'GeometryCollection'}],
+                {'coordinates': [], 'type': 'Point'},
+                {'coordinates': [], 'type': 'Polygon'}
+            ]
         }
 
-        expected = 'GEOMETRYCOLLECTION (%s)' % ','.join('%s EMPTY' % typ for typ in wkt._type_map_caps_to_mixed.keys())
+        expected = 'GEOMETRYCOLLECTION (%s)' % ','.join('%s EMPTY' % typ for typ in sorted(wkt._type_map_caps_to_mixed.keys()))
 
         self.assertEqual(expected, wkt.dumps(gc))
 
@@ -1063,18 +1064,19 @@ class GeometryCollectionLoadsTestCase(unittest.TestCase):
         self.assertEqual(expected, wkt.loads(gc))
 
     def test_all_types_empty(self):
-        gc = 'GEOMETRYCOLLECTION (%s)' % ','.join('%s EMPTY' % typ for typ in wkt._type_map_caps_to_mixed.keys())
+        gc = 'GEOMETRYCOLLECTION (%s)' % ','.join('%s EMPTY' % typ for typ in sorted(wkt._type_map_caps_to_mixed.keys()))
 
         expected = {
             'type': 'GeometryCollection',
             'geometries': [
-                {'coordinates': [], 'type': 'Point'},
+                {'geometries': [], 'type': 'GeometryCollection'},
                 {'coordinates': [], 'type': 'LineString'},
-                {'coordinates': [], 'type': 'Polygon'},
-                {'coordinates': [], 'type': 'MultiPoint'},
                 {'coordinates': [], 'type': 'MultiLineString'},
+                {'coordinates': [], 'type': 'MultiPoint'},
                 {'coordinates': [], 'type': 'MultiPolygon'},
-                {'geometries': [], 'type': 'GeometryCollection'}],
+                {'coordinates': [], 'type': 'Point'},
+                {'coordinates': [], 'type': 'Polygon'}
+            ]
         }
         self.assertEqual(expected, wkt.loads(gc))
 

--- a/geomet/tests/wkt_test.py
+++ b/geomet/tests/wkt_test.py
@@ -822,6 +822,31 @@ class GeometryCollectionDumpsTestCase(unittest.TestCase):
         )
         self.assertEqual(expected, wkt.dumps(gc, decimals=3))
 
+    def test_with_empty_component_simple(self):
+        gc = {
+            'type': 'GeometryCollection',
+            'geometries': [
+                {'type': 'Point', 'coordinates': [0, 0]},
+                {'type': 'Point', 'coordinates': []}
+            ]
+        }
+
+        expected = 'GEOMETRYCOLLECTION (POINT (0 0),POINT EMPTY)'
+
+        self.assertEqual(expected, wkt.dumps(gc, decimals=0))
+
+    def test_with_empty_component(self):
+        # Example from https://github.com/geomet/geomet/issues/49
+        gc = {'type': 'GeometryCollection', 'geometries': [
+            {'type': 'Polygon', 'coordinates': [
+                [[27.0, 25.0], [102.0, 36.0], [102.0, 46.0], [92.0, 61.0], [13.0, 41.0], [16.0, 30.0], [27.0, 25.0]]]},
+            {'type': 'LineString', 'coordinates': []}
+        ]}
+
+        expected = 'GEOMETRYCOLLECTION (POLYGON ((27 25, 102 36, 102 46, 92 61, 13 41, 16 30, 27 25)),LINESTRING EMPTY)'
+
+        self.assertEqual(expected, wkt.dumps(gc, decimals=0))
+
 
 class GeometryCollectionLoadsTestCase(unittest.TestCase):
 
@@ -961,6 +986,31 @@ class GeometryCollectionLoadsTestCase(unittest.TestCase):
             'type': 'GeometryCollection',
             'meta': dict(srid=662),
         }
+        self.assertEqual(expected, wkt.loads(gc))
+
+    def test_with_empty_component_simple(self):
+        gc = 'GEOMETRYCOLLECTION (POINT (0 0), POINT EMPTY)'
+
+        expected = {
+            'type': 'GeometryCollection',
+            'geometries': [
+                {'type': 'Point', 'coordinates': [0, 0]},
+                {'type': 'Point', 'coordinates': []}
+            ]
+        }
+
+        self.assertEqual(expected, wkt.loads(gc))
+
+    def test_with_empty_component(self):
+        # Example from https://github.com/geomet/geomet/issues/49
+        gc = 'GEOMETRYCOLLECTION (POLYGON((27 25,102 36,102 46,92 61,13 41,16 30,27 25)),LINESTRING EMPTY)'
+
+        expected = {'type': 'GeometryCollection', 'geometries': [
+            {'type': 'Polygon', 'coordinates': [
+                [[27.0, 25.0], [102.0, 36.0], [102.0, 46.0], [92.0, 61.0], [13.0, 41.0], [16.0, 30.0], [27.0, 25.0]]]},
+            {'type': 'LineString', 'coordinates': []}
+        ]}
+
         self.assertEqual(expected, wkt.loads(gc))
 
 

--- a/geomet/wkt.py
+++ b/geomet/wkt.py
@@ -601,8 +601,11 @@ def _load_geometrycollection(tokens, string):
         A GeoJSON `dict` GeometryCollection representation of the WKT
         ``string``.
     """
-    open_paren = next(tokens)
-    if not open_paren == '(':
+    next_token = next(tokens)
+
+    if next_token == 'EMPTY':
+        return dict(type='GeometryCollection', geometries=[])
+    elif not next_token == '(':
         raise ValueError(INVALID_WKT_FMT % string)
 
     geoms = []


### PR DESCRIPTION
This PR addresses the issues raised in #49, where nested empty geometries in `GEOMETRYCOLLECTION`s were not being parsed appropriately. I moved the handling logic into the individual dump(s)/load(s) functions for each geometry type. 

There's definitely some repeated code here which can be factored out, I just wanted to get a PR open to get some feedback going.

Also, if individual functions are handling the empty case, then we can probably remove the logic in the top-level `dumps` and `loads` functions which are handling these cases to avoid handling it in two places, right? There's probably a small speedup gained by short-circuiting there, but I can't imagine it's that much.