### PR TITLE
Use chain.from_iterable in wkb.py

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -5,3 +5,4 @@ Maralla <maralla.ai@gmail.com> - November 2013
 Sean Gillies <sean.gillies@gmail.com> - August 2014
 Tom Caruso <carusot42@gmail.com> - December 2018
 Paul Bryan <pbryan@anode.ca> - August 2019
+Ram Rachum <ram@rachum.com> - June 2020

--- a/geomet/wkb.py
+++ b/geomet/wkb.py
@@ -100,8 +100,8 @@ _WKB = {
 #: geometry type.
 #: NOTE: Byte ordering is big endian.
 _BINARY_TO_GEOM_TYPE = dict(
-    chain(*((reversed(x) for x in wkb_map.items())
-            for wkb_map in _WKB.values()))
+    chain.from_iterable(((reversed(x) for x in wkb_map.items())
+                        for wkb_map in _WKB.values()))
 )
 
 _INT_TO_DIM_LABEL = {2: '2D', 3: 'Z', 4: 'ZM'}


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.