### PR TITLE
Fix style and geomet.esri.loads bug

### DIFF
--- a/geomet/esri.py
+++ b/geomet/esri.py
@@ -39,16 +39,16 @@ def loads(string):
     :returns:
          A GeoJSON `dict` representing the geometry read from the file.
     """
-    if isinstance(string, str):
-        string = json.loads(string)
-    if 'rings' in string:
-        return _esri_to_geojson_convert['rings'](string)
-    elif 'paths' in string:
-        return _esri_to_geojson_convert['paths'](string)
-    elif 'x' in string or 'y' in string:
-        return _esri_to_geojson_convert['x'](string)
-    elif 'points' in string:
-        return _esri_to_geojson_convert['points'](string)
+    data = json.loads(string)
+
+    if 'rings' in data:
+        return _esri_to_geojson_convert['rings'](data)
+    elif 'paths' in data:
+        return _esri_to_geojson_convert['paths'](data)
+    elif 'x' in data or 'y' in data:
+        return _esri_to_geojson_convert['x'](data)
+    elif 'points' in data:
+        return _esri_to_geojson_convert['points'](data)
     else:
         raise geomet.InvalidGeoJSONException('Invalid EsriJSON: %s' % string)
 

--- a/geomet/esri.py
+++ b/geomet/esri.py
@@ -126,7 +126,8 @@ def _dump_geojson_multipoint(obj, srid=None):
 
 def _dump_geojson_polyline(obj, srid=None):
     """
-    Loads GeoJSON to Esri JSON for Geometry type LineString and MultiLineString.
+    Loads GeoJSON to Esri JSON for Geometry type LineString and
+    MultiLineString.
 
     """
     coordkey = 'coordinates'
@@ -224,8 +225,13 @@ def _to_gj_polyline(data):
     Input parameters and return value are the MULTILINESTRING equivalent to
     :func:`_dump_point`.
     """
-    return {'type': 'MultiLineString', 'coordinates': [
-        [((pt[0], pt[1]) if pt else None) for pt in part] for part in data["paths"]]}
+    return {
+        'type': 'MultiLineString',
+        'coordinates': [
+            [((pt[0], pt[1]) if pt else None) for pt in part]
+            for part in data["paths"]
+        ],
+    }
 
 
 _esri_to_geojson_convert = {

--- a/geomet/tests/esri_test.py
+++ b/geomet/tests/esri_test.py
@@ -166,30 +166,30 @@ class TestEsriJSONtoGeoJSON(unittest.TestCase):
             invalid = {'Tetrahedron': [[1, 2, 34], [2, 3, 4], [
                 4, 5, 6]], 'spatialReference': {'wkid': 4326}}
             with self.assertRaises(InvalidGeoJSONException) as ar:
-                esri.loads(invalid)
+                esri.loads(json.dumps(invalid))
             self.assertTrue(str(ar.exception).lower().find(
                 'invalid esrijson') > -1)
         else:
             invalid = {'Tetrahedron': [[1, 2, 34], [2, 3, 4], [
                 4, 5, 6]], 'spatialReference': {'wkid': 4326}}
             with self.assertRaises(InvalidGeoJSONException) as ar:
-                esri.loads(invalid)
+                esri.loads(json.dumps(invalid, sort_keys=True))
             self.assertEqual(
-                "Invalid EsriJSON: "
-                "{'Tetrahedron': [[1, 2, 34], [2, 3, 4], [4, 5, 6]], "
-                "'spatialReference': {'wkid': 4326}}",
+                'Invalid EsriJSON: '
+                '{"Tetrahedron": [[1, 2, 34], [2, 3, 4], [4, 5, 6]], '
+                '"spatialReference": {"wkid": 4326}}',
                 str(ar.exception)
             )
 
     def test_loads_to_geojson_point(self):
         """Tests Loading Esri Point Geometry to Point GeoJSON"""
-        self.assertEqual(esri.loads(esri_json_pt),
+        self.assertEqual(esri.loads(json.dumps(esri_json_pt)),
                          {'type': 'Point', 'coordinates': (25282, 43770)})
 
     def test_loads_to_geojson_multipoint(self):
         """Tests Loading Esri MultiPoint Geometry to MultiPoint GeoJSON"""
         self.assertEqual(
-            esri.loads(esri_json_mpt),
+            esri.loads(json.dumps(esri_json_mpt)),
             {
                 'type': 'Multipoint',
                 'coordinates': [
@@ -201,7 +201,7 @@ class TestEsriJSONtoGeoJSON(unittest.TestCase):
 
     def test_loads_to_geojson_linstring(self):
         """Tests Loading Esri Point Geometry to MultiLineString GeoJSON"""
-        self.assertEqual(esri.loads(esri_json_polylines),
+        self.assertEqual(esri.loads(json.dumps(esri_json_polylines)),
                          {'type': 'MultiLineString',
                           'coordinates': [[(-97.06138,
                                             32.837),
@@ -219,7 +219,7 @@ class TestEsriJSONtoGeoJSON(unittest.TestCase):
     def test_loads_to_geojson_polygon(self):
         """Tests Loading Esri Polygon Geometry to MultiPolygon GeoJSON"""
         self.assertEqual(
-            esri.loads(esri_json_polygon),
+            esri.loads(json.dumps(esri_json_polygon)),
             {
                 'type': 'MultiPolygon',
                 'coordinates': [
@@ -234,39 +234,39 @@ class TestEsriJSONtoGeoJSON(unittest.TestCase):
 
     def test_loads_empty_pt_to_gj(self):
         """Tests Loading an empty Esri JSON Point to GeoJSON"""
-        geom = {"x": None, "y": None, "spatialReference": {"wkid": 3857}}
+        geom = json.dumps(
+            {"x": None, "y": None, "spatialReference": {"wkid": 3857}}
+        )
         self.assertEqual(esri.loads(geom),
                          {'type': 'Point', 'coordinates': ()})
 
     def test_loads_to_empty_mpt_to_gj(self):
         """Tests Loading an empty Esri JSON MultiPoint to GeoJSON"""
-        geom = {
+        geom = json.dumps({
             "points": [],
             "spatialReference": {"wkid": 4326}
-        }
+        })
         geom_match = {'type': 'Multipoint', 'coordinates': []}
         self.assertEqual(esri.loads(geom),
                          geom_match)
 
     def test_loads_empty_polyline_to_gj(self):
         """Tests Loading an empty Esri JSON Polyline to GeoJSON"""
-        geom = {
+        geom = json.dumps({
             "paths": [],
             "spatialReference": {"wkid": 4326}
-        }
+        })
         geom_match = {'type': 'MultiLineString', 'coordinates': []}
-        self.assertEqual(esri.loads(geom),
-                         geom_match)
+        self.assertEqual(esri.loads(geom), geom_match)
 
     def test_loads_empty_polygon_to_gj(self):
         """Tests Loading an empty Esri JSON Polygon to GeoJSON"""
-        geom = {
+        geom = json.dumps({
             "rings": [],
             "spatialReference": {"wkid": 4326}
-        }
+        })
         geom_match = {'type': 'MultiPolygon', 'coordinates': []}
-        self.assertEqual(esri.loads(geom),
-                         geom_match)
+        self.assertEqual(esri.loads(geom), geom_match)
 
 
 class TestGeoJSONtoEsriJSON(unittest.TestCase):

--- a/geomet/tests/esri_test.py
+++ b/geomet/tests/esri_test.py
@@ -27,17 +27,27 @@ IS_PY34 = six.PY34
 
 esri_json_pt = {"x": 25282, "y": 43770, "spatialReference": {"wkid": 3857}}
 esri_json_mpt = {
-    "points": [[-97.06138, 32.837], [-97.06133, 32.836], [-97.06124, 32.834], [-97.06127, 32.832]],
+    "points": [
+        [-97.06138, 32.837], [-97.06133, 32.836],
+        [-97.06124, 32.834], [-97.06127, 32.832],
+    ],
     "spatialReference": {"wkid": 4326}
 }
 esri_json_polylines = {
-    "paths": [[[-97.06138, 32.837], [-97.06133, 32.836], [-97.06124, 32.834], [-97.06127, 32.832]],
-              [[-97.06326, 32.759], [-97.06298, 32.755]]],
+    "paths": [
+        [[-97.06138, 32.837], [-97.06133, 32.836],
+         [-97.06124, 32.834], [-97.06127, 32.832]],
+        [[-97.06326, 32.759], [-97.06298, 32.755]]
+    ],
     "spatialReference": {"wkid": 4326}
 }
 esri_json_polygon = {
-    "rings": [[[-97.06138, 32.837], [-97.06133, 32.836], [-97.06124, 32.834], [-97.06127, 32.832], [-97.06138, 32.837]],
-              [[-97.06326, 32.759], [-97.06298, 32.755], [-97.06153, 32.749], [-97.06326, 32.759]]],
+    "rings": [
+        [[-97.06138, 32.837], [-97.06133, 32.836], [-97.06124, 32.834],
+         [-97.06127, 32.832], [-97.06138, 32.837]],
+        [[-97.06326, 32.759], [-97.06298, 32.755],
+         [-97.06153, 32.749], [-97.06326, 32.759]]
+    ],
     "spatialReference": {"wkid": 4326}
 }
 
@@ -78,8 +88,13 @@ gj_multi_polygon = {'type': 'MultiPolygon',
                                          32.759)]]]}
 gj_polygon = {"type": "Polygon", "coordinates": [
     [[100.0, 0.0], [101.0, 0.0], [101.0, 1.0], [100.0, 1.0], [100.0, 0.0]]]}
-gj_multi_pt = {'type': 'Multipoint', 'coordinates': [
-    [-97.06138, 32.837], [-97.06133, 32.836], [-97.06124, 32.834], [-97.06127, 32.832]]}
+gj_multi_pt = {
+    'type': 'Multipoint',
+    'coordinates': [
+        [-97.06138, 32.837], [-97.06133, 32.836],
+        [-97.06124, 32.834], [-97.06127, 32.832],
+    ]
+}
 
 
 class TestIOReaderWriter(unittest.TestCase):
@@ -114,7 +129,6 @@ class TestIOReaderWriter(unittest.TestCase):
         """
         Tests the `load` method
         """
-        vcheck = {'type': 'Point', 'coordinates': (25282, 43770)}
         if IS_PY3:
             with tempfile.TemporaryDirectory() as d:
                 fp = os.path.join(d, "test.json")
@@ -122,9 +136,13 @@ class TestIOReaderWriter(unittest.TestCase):
                     esri.dump(gj_pt, w)
                 with open(fp, 'r') as r:
                     self.assertEqual(
-                        esri.load(r), {
-                            'spatialReference': {
-                                'wkid': 4326}, 'x': 25282, 'y': 43770})
+                        esri.load(r),
+                        {
+                            'spatialReference': {'wkid': 4326},
+                            'x': 25282,
+                            'y': 43770,
+                        }
+                    )
         else:
             d = tempfile.gettempdir()
             fp = os.path.join(d, "test.json")
@@ -157,8 +175,11 @@ class TestEsriJSONtoGeoJSON(unittest.TestCase):
             with self.assertRaises(InvalidGeoJSONException) as ar:
                 esri.loads(invalid)
             self.assertEqual(
-                "Invalid EsriJSON: {'Tetrahedron': [[1, 2, 34], [2, 3, 4], [4, 5, 6]], 'spatialReference': {'wkid': 4326}}", str(
-                    ar.exception))
+                "Invalid EsriJSON: "
+                "{'Tetrahedron': [[1, 2, 34], [2, 3, 4], [4, 5, 6]], "
+                "'spatialReference': {'wkid': 4326}}",
+                str(ar.exception)
+            )
 
     def test_loads_to_geojson_point(self):
         """Tests Loading Esri Point Geometry to Point GeoJSON"""
@@ -167,9 +188,16 @@ class TestEsriJSONtoGeoJSON(unittest.TestCase):
 
     def test_loads_to_geojson_multipoint(self):
         """Tests Loading Esri MultiPoint Geometry to MultiPoint GeoJSON"""
-        self.assertEqual(esri.loads(esri_json_mpt),
-                         {'type': 'Multipoint', 'coordinates': [[-97.06138, 32.837], [-97.06133, 32.836],
-                                                                [-97.06124, 32.834], [-97.06127, 32.832]]})
+        self.assertEqual(
+            esri.loads(esri_json_mpt),
+            {
+                'type': 'Multipoint',
+                'coordinates': [
+                    [-97.06138, 32.837], [-97.06133, 32.836],
+                    [-97.06124, 32.834], [-97.06127, 32.832],
+                ],
+            }
+        )
 
     def test_loads_to_geojson_linstring(self):
         """Tests Loading Esri Point Geometry to MultiLineString GeoJSON"""
@@ -190,11 +218,19 @@ class TestEsriJSONtoGeoJSON(unittest.TestCase):
 
     def test_loads_to_geojson_polygon(self):
         """Tests Loading Esri Polygon Geometry to MultiPolygon GeoJSON"""
-        self.assertEqual(esri.loads(esri_json_polygon),
-                         {'type': 'MultiPolygon', 'coordinates': [
-                             [[(-97.06138, 32.837), (-97.06133, 32.836), (-97.06124, 32.834), (-97.06127, 32.832), (-97.06138, 32.837)]],
-                             [[(-97.06326, 32.759), (-97.06298, 32.755), (-97.06153, 32.749), (-97.06326, 32.759)]]
-                         ]})
+        self.assertEqual(
+            esri.loads(esri_json_polygon),
+            {
+                'type': 'MultiPolygon',
+                'coordinates': [
+                    [[(-97.06138, 32.837), (-97.06133, 32.836),
+                      (-97.06124, 32.834), (-97.06127, 32.832),
+                      (-97.06138, 32.837)]],
+                    [[(-97.06326, 32.759), (-97.06298, 32.755),
+                      (-97.06153, 32.749), (-97.06326, 32.759)]],
+                ]
+            }
+        )
 
     def test_loads_empty_pt_to_gj(self):
         """Tests Loading an empty Esri JSON Point to GeoJSON"""
@@ -253,8 +289,13 @@ class TestGeoJSONtoEsriJSON(unittest.TestCase):
 
     def test_dumps_to_esrijson_polyline1(self):
         """Tests Converting GeoJSON LineString to Esri JSON Polyline"""
-        self.assertEqual(esri.dumps(gj_lintstring), {'paths': [
-                         [[100.0, 100.0], [5.0, 5.0]]], 'spatialReference': {'wkid': 4326}})
+        self.assertEqual(
+            esri.dumps(gj_lintstring),
+            {
+                'paths': [[[100.0, 100.0], [5.0, 5.0]]],
+                'spatialReference': {'wkid': 4326},
+            }
+        )
 
     def test_dumps_to_esrijson_polyline2(self):
         """Tests Converting GeoJSON MultiLineString to Esri JSON Polyline"""

--- a/geomet/wkb.py
+++ b/geomet/wkb.py
@@ -922,7 +922,7 @@ def _load_geometrycollection(big_endian, type_bytes, data_bytes):
 
 
 _dumps_registry = {
-    'Point':  _dump_point,
+    'Point': _dump_point,
     'LineString': _dump_linestring,
     'Polygon': _dump_polygon,
     'MultiPoint': _dump_multipoint,

--- a/geomet/wkt.py
+++ b/geomet/wkt.py
@@ -300,8 +300,14 @@ def _dump_multilinestring(obj, decimals):
     if not coords:
         fmt = 'EMPTY'
     else:
-        linestrs = ('(%s)' % ', '.join(' '.join(_round_and_pad(c, decimals)
-                    for c in pt) for pt in linestr) for linestr in coords)
+        linestrs = (
+            '(%s)' %
+            ', '.join(
+                ' '.join(
+                    _round_and_pad(
+                        c,
+                        decimals) for c in pt
+                ) for pt in linestr) for linestr in coords)
 
         fmt = '(%s)' % ', '.join(ls for ls in linestrs)
 
@@ -632,7 +638,7 @@ def _load_geometrycollection(tokens, string):
 
 
 _dumps_registry = {
-    'Point':  _dump_point,
+    'Point': _dump_point,
     'LineString': _dump_linestring,
     'Polygon': _dump_polygon,
     'MultiPoint': _dump_multipoint,


### PR DESCRIPTION
This patch addresses style issues introduced by https://github.com/geomet/geomet/pull/63.

It also solves a minor bug in `geomet.esri.loads`, which led to intermittent test failure as a result of hash ordering of dictionary keys in comparison to expected results.