### PR TITLE
Use assertNotEqual instead of assertNotEquals for Python 3.11 compatibility.

### DIFF
--- a/geomet/tests/test_geopackage.py
+++ b/geomet/tests/test_geopackage.py
@@ -251,7 +251,7 @@ class TestLoadsInvalidGPB(unittest.TestCase):
         with self.assertRaises(ValueError) as exc:
             geopackage.loads(gpkg)
 
-        self.assertEquals(
+        self.assertEqual(
             str(exc.exception),
             (
                 "Could not read Geopackage geometry because of errors: "
@@ -272,7 +272,7 @@ class TestLoadsInvalidGPB(unittest.TestCase):
             geopackage.loads(gpkg)
 
         print(str(exc.exception))
-        self.assertEquals(
+        self.assertEqual(
             str(exc.exception),
             ("Could not read Geopackage geometry because of errors: "
              "Geopackage version must be 0")
@@ -291,7 +291,7 @@ class TestLoadsInvalidGPB(unittest.TestCase):
             geopackage.loads(gpkg)
 
         print(str(exc.exception))
-        self.assertEquals(
+        self.assertEqual(
             str(exc.exception),
             ("Could not read Geopackage geometry because of errors: "
              "Envelope indicator must be between 0-4")


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268 .