### PR TITLE
Update supported Python versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ py38_container: &py38_container
         - image: circleci/python:3.8
     resource_class: small
     working_directory: ~/project
+py39_container: &py39_container
+    docker:
+        - image: circleci/python:3.9
+    resource_class: small
+    working_directory: ~/project
 
 filter_build_test_package: &filter_build_test_package
     filters:
@@ -118,6 +123,11 @@ jobs:
         steps:
             - build_test_package:
                 py_ver: "38"
+    build_test_package_py39:
+        <<: *py39_container
+        steps:
+            - build_test_package:
+                py_ver: "39"
     publish_to_test_pypi:
         <<: *py37_container
         steps:
@@ -163,6 +173,9 @@ workflows:
             - build_test_package_py38:
                 <<: *filter_build_test_package
                 requires: [code_checkout]
+            - build_test_package_py39:
+                <<: *filter_build_test_package
+                requires: [code_checkout]
     release:
         jobs:
             - code_checkout:
@@ -185,6 +198,9 @@ workflows:
             - build_test_package_py38:
                 <<: *filter_release
                 requires: [code_checkout]
+            - build_test_package_py39:
+                <<: *filter_release
+                requires: [code_checkout]
             - publish_to_test_pypi:
                 <<: *filter_release
                 context: "Test PyPI"
@@ -195,6 +211,7 @@ workflows:
                     - build_test_package_py36
                     - build_test_package_py37
                     - build_test_package_py38
+                    - build_test_package_py39
             - approve_publish:
                 <<: *filter_release
                 type: approval

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -8,3 +8,4 @@ Paul Bryan <pbryan@anode.ca> - August 2019
 Ram Rachum <ram@rachum.com> - June 2020
 Andrew Chapkowski <andrewonboe@gmail.com> - June 2020
 Vadim Kozyrevskii <vadikko2@mail.ru> - January 2021
+Stian Jensen <me@stianj.com> - January 2022

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Scientific/Engineering :: GIS',
     ],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py27,py34,py35,py36,py37,py38,style
+envlist = py27,py34,py35,py36,py37,py38,py39,style
 
 [testenv]
 install_command = pip install -U {opts} {packages}


### PR DESCRIPTION
Python 3.6 and older is EOL now, so they're removed from testing.
And new python versions 3.8 and 3.9 are added.

I believe nose, which is used for tests, does not support python 3.10
(and is unmaintained, so it probably never will), so I didn't include
python 3.10 in testing for now.

Nose will probably have to be replaced at some point (for instance by
pytest).