### PR TITLE
fix issue with GeoJSON to Esri JSON for MultiPolygon type of Geometries.

### DIFF
--- a/geomet/esri.py
+++ b/geomet/esri.py
@@ -146,22 +146,19 @@ def _dump_geojson_polygon(data, srid=None):
     """
     coordkey = 'coordinates'
     coordinates = data[coordkey]
-    typekey = ([d for d in data if d.lower() == 'type']
-               or ['type']).pop()
+    typekey = ([d for d in data if d.lower() == 'type'] or ['type']).pop()
     if data[typekey].lower() == "polygon":
         coordinates = [coordinates]
     part_list = []
     for part in coordinates:
-        part_item = []
-        for idx, ring in enumerate(part):
-            if idx:
-                part_item.append(None)
-            for coord in ring:
-                part_item.append(coord)
-        if part_item:
-            part_list.append(part_item)
+        if len(part) == 1:
+            part_list.append(part[0])
+        else:
+            for seg in part:
+                part_list.append([list(coord) for coord in seg])
     srid = _extract_geojson_srid(data) or srid
     return {'rings': part_list, "spatialReference": {"wkid": srid}}
+
 
 
 def _to_gj_point(obj):


### PR DESCRIPTION
There is an issue with Geomet and converting GeoJSON MultiPolygon to Esri Polygon.  This PR fixes the issue where the values should be flattened a bit. 

The issue was caused by the `None` value in the list.  Instead of being a `None` it needs to be a list.  The `None` value was the ArcPy Geometry representation.  


```
result_gj = {'rings': [[[102, 2], [103, 2], [103, 3], [102, 3], [102, 2]], [[100, 0], [101, 0], [101, 1], [100, 1], [100, 0]], [[100.2, 0.2], [100.2, 0.8], [100.8, 0.8], [100.8, 0.2], [100.2, 0.2]]], 'spatialReference': {'wkid': 4326}}
from geomet import esri
geojson_mp = {
        "type": "MultiPolygon",
        "coordinates": [
            [[[102, 2], [103, 2], [103, 3], [102, 3], [102, 2]]],
            [
                [[100, 0], [101, 0], [101, 1], [100, 1], [100, 0]],
                [[100.2, 0.2], [100.2, 0.8], [100.8, 0.8], [100.8, 0.2], [100.2, 0.2]],
            ],
        ],
    }
geometry = esri.dumps(geojson_mp)
assert geometry == result_gj


```